### PR TITLE
refactor: remove netevent exploits

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -93,8 +93,9 @@ local function enterRobberyHouse(house)
     end
     for k, v in pairs(Config.Houses[house]['loot']) do
         lib.requestModel(v.prop, 10000)
-        if v.taken == false then 
-            k = CreateObject(v.prop, coords.x + v.coords.x, coords.y + v.coords.y, coords.z + v.coords.z, false, false, false)
+        if v.taken == false then
+            local objectCoords = vector3(coords.x + v.coords.x, coords.y + v.coords.y, coords.z + v.coords.z)
+            k = CreateObject(v.prop, objectCoords.x, objectCoords.y, objectCoords.z, false, false, false)
             if v.rotation == nil then
                 v.rotation = 180.0
             end
@@ -122,7 +123,7 @@ local function enterRobberyHouse(house)
                                     ClearPedTasks(PlayerPedId())
 						            DeleteObject(k)
                                     TriggerServerEvent('md-houserobbery:server:setlootused', house, v.num)
-                                    TriggerServerEvent('md-houserobbery:server:GetLoot', Config.Houses[house].tier, v.type)
+                                    TriggerServerEvent('md-houserobbery:server:GetLoot', Config.Houses[house].tier, v.type, objectCoords)
                                 else
                                    QBCore.Functions.Notify("Dude You Cant Even Do This, C'mon", "error")
                                 end
@@ -622,7 +623,7 @@ RegisterNetEvent("md-houserobberies:client:sellloot", function(data)
     local chance = math.random(1,100)
    
     if data.success >= chance then 
-        TriggerServerEvent('md-houserobberies:server:sellloot', data.item, data.min, data.max)
+        TriggerServerEvent('md-houserobberies:server:sellloot', data.item)
     else
         TriggerServerEvent('md-houserobberies:server:loseloot', data.item)
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -40,16 +40,24 @@ RegisterNetEvent('md-houserobbery:server:accessbreak', function(tier)
     end
 end)        
 
-RegisterNetEvent('md-houserobberies:server:sellloot', function(item, min, max)
+RegisterNetEvent('md-houserobberies:server:sellloot', function(itemName)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    local price = math.random(min, max)
-    local itemsell = Player.Functions.GetItemByName(item)
+    local itemConfig
+    for i = 1, #Config.BlackMarket do
+        if Config.BlackMarket[i].item == itemName then
+            itemConfig = Config.BlackMarket[i]
+            break
+        end
+    end
+    if not itemConfig then return end -- Don't allow players to turn any item into any amount of money
+    local price = math.random(itemConfig.minvalue, itemConfig.maxvalue) -- Retrieve price from config don't trust client
+    local itemsell = Player.Functions.GetItemByName(itemName)
 
     if itemsell and itemsell.amount > 0 then
-        if   Player.Functions.RemoveItem(item, itemsell.amount) then
+        if   Player.Functions.RemoveItem(itemName, itemsell.amount) then
             Player.Functions.AddMoney('cash', price * itemsell.amount)
-              TriggerClientEvent('QBCore:Notify', src, "You received " .. itemsell.amount * Price .. " of Cash.", "success")
+              TriggerClientEvent('QBCore:Notify', src, "You received " .. itemsell.amount * price .. " of Cash.", "success")
         end
     end
 end)
@@ -98,11 +106,12 @@ RegisterNetEvent('md-houserobbery:server:setlootused', function(house, k)
     Config.Houses[house]['loot'][k].taken = true
 end)
 
-RegisterNetEvent('md-houserobbery:server:GetLoot', function(tier, rewardtype)
+RegisterNetEvent('md-houserobbery:server:GetLoot', function(tier, rewardtype, objectCoords)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
+    local playerCoords = GetEntityCoords(GetPlayerPed(src))
+    if #(playerCoords - objectCoords) > 1 then return end -- Prevent loot vacuums
     local chance = math.random(1,100)
-    local count = nil
     local cashamount = math.random(Config.CashMin, Config.CashMax)
     local randomItem = Config.Rewards[tier][rewardtype][math.random(1, #Config.Rewards[tier][rewardtype])]
     local itemInfo = QBCore.Shared.Items[randomItem]


### PR DESCRIPTION
This prevents basic injector exploits in the netevents by not trusting the client to give us the price for items they want to sell and that said item actually exists in the configuration.

Also prevents players from injecting against the GetLoot event by doing a basic coordinate check. This could be better written and have the server check where the coordinates are supposed to be for a given house by defining the loot dynamically per house and storing it in a table serverside.